### PR TITLE
[admin] 5 - Updates angular.json builder to builder:application

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -15,11 +15,11 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": "dist/friendlychat",
             "index": "src/index.html",
-            "main": "src/main.ts",
+            "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],


### PR DESCRIPTION
This is done to support AppEngine hosting.  I got build errors in firebase AppHosting console  
   throw new Error("Only the Angular application builder is supported. Please refer to https://angular.dev/tools/cli/build-system-migration#for-existing-applications guide to upgrade your builder to the Angular application builder. ");"


Unfortunately the emulators and auth don't seem to work in this configuration though.  